### PR TITLE
Check if `$config['connection']` is not empty in SalesforcesTable

### DIFF
--- a/src/Model/Table/SalesforcesTable.php
+++ b/src/Model/Table/SalesforcesTable.php
@@ -49,7 +49,7 @@ class SalesforcesTable extends SalesforceTable
         $this->setDisplayField('Id');
         $this->setPrimaryKey('Id');
 
-        if (!empty($config['connection']->config()['my_wsdl'])) {
+        if (!empty($config['connection']) && !empty($config['connection']->config()['my_wsdl'])) {
             $wsdl = CONFIG . DS . $config['connection']->config()['my_wsdl'];
         } else {
             throw new Exception('You need to provide a WSDL');


### PR DESCRIPTION
This PR checks if `$config['connection']` is not empty to resolve bug:

```
Error: [Error] Call to a member function config() on null in src/Model/Table/SalesforcesTable.php on line 52
```

If the connection index does not exist it will now go into the else condition and throw a catchable exception.